### PR TITLE
fix: pass region string directly in updateLaunchConfig.mjs instead of broken enum lookup

### DIFF
--- a/updateLaunchConfig.mjs
+++ b/updateLaunchConfig.mjs
@@ -28,7 +28,7 @@
 
 import fs from "fs";
 import path from "path";
-import contentstack, { Region } from "@contentstack/delivery-sdk";
+import contentstack from "@contentstack/delivery-sdk";
 import dotenv from "dotenv";
 
 // Load environment variables from .env.local
@@ -48,7 +48,7 @@ async function getAllLinks() {
     apiKey: process.env.NEXT_PUBLIC_CONTENTSTACK_API_KEY,
     deliveryToken: process.env.NEXT_PUBLIC_CONTENTSTACK_DELIVERY_TOKEN,
     environment: process.env.NEXT_PUBLIC_CONTENTSTACK_ENVIRONMENT,
-    region: Region[process.env.NEXT_PUBLIC_CONTENTSTACK_REGION],
+    region: process.env.NEXT_PUBLIC_CONTENTSTACK_REGION,
   });
 
   // Fetch URLs from all content types in parallel for better performance


### PR DESCRIPTION
## Problem
`updateLaunchConfig.mjs` was using a TypeScript enum reverse-lookup to
resolve the region value:

  region: Region[process.env.NEXT_PUBLIC_CONTENTSTACK_REGION]

The `Region` enum in `@contentstack/delivery-sdk` only has three keys:
EU, AZURE_EU, GCP_EU. Any other value — NA, azure-na, gcp-na, or even
lowercase eu — resolves to undefined, so the SDK was silently receiving
no region at all. Cache priming on Contentstack Launch deployments was
broken for every region except exact uppercase EU.

The app itself was unaffected at runtime since lib/contentstack.ts
already passed the string directly.

## Fix
Drop the enum lookup, pass the env var string directly — the same
approach used everywhere else in the codebase. Also removed the now
unused Region import.